### PR TITLE
Configure fastapi for vercel subdirectory deployment

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,10 +1,13 @@
-from http.server import BaseHTTPRequestHandler
+import os
+import sys
 
-class handler(BaseHTTPRequestHandler):
+# Ensure the local src/ directory is importable when running on Vercel
+CURRENT_DIR = os.path.dirname(__file__)
+SRC_DIR = os.path.normpath(os.path.join(CURRENT_DIR, "..", "src"))
+if SRC_DIR not in sys.path:
+    sys.path.append(SRC_DIR)
 
-    def do_GET(self):
-        self.send_response(200)
-        self.send_header('Content-type','text/plain')
-        self.end_headers()
-        self.wfile.write('Hello, world!'.encode('utf-8'))
-        return
+from tm_shared_pad import app as fastapi_app
+
+# Vercel's Python runtime will detect this ASGI app
+app = fastapi_app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+fastapi[standard]>=0.116.1

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,10 @@
 {
-"redirects": [{ "source": "/", "destination": "/api" }]
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.12"
+    }
+  },
+  "routes": [
+    { "src": "/(.*)", "dest": "/api/index.py" }
+  ]
 }


### PR DESCRIPTION
Configure Vercel to deploy and serve the FastAPI application from `src/tm_shared_pad` by updating the serverless entrypoint, Vercel configuration, and dependencies.

The previous Vercel setup only served a static `api/index.py` response. This PR modifies the Vercel configuration to correctly identify the FastAPI application in `src/tm_shared_pad` as the main entrypoint, allowing all routes to be handled by the FastAPI server.

---
<a href="https://cursor.com/background-agent?bcId=bc-7031b690-1bfe-49a4-9c92-0fa4f70f39c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7031b690-1bfe-49a4-9c92-0fa4f70f39c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

