### PR TITLE
Configure vercel json and file location

### DIFF
--- a/public/plugin.json
+++ b/public/plugin.json
@@ -1,0 +1,45 @@
+{
+	"id": "shared_pad",
+	"uuid": "4b0ecb8a-3a76-4f23-91a3-0d89d4b59d10",
+	"title": "Shared Pad",
+	"emoji": "🗒️",
+	"version": 1,
+	"implementationType": "http",
+	"httpAction": {
+		"id": "c3f8b5f2-3a2c-4b6e-9a1a-2f7f6c1a9ef0",
+		"method": "POST",
+		"url": "https://typingmind-plugin-server-j330.onrender.com/pad",
+		"hasHeaders": true,
+		"requestHeaders": "{\n  \"Content-Type\": \"application/json\"\n}",
+		"hasBody": true,
+		"requestBodyFormat": "json",
+		"requestBody": "{\n  \"action\": \"{action}\",\n  \"text\": \"{text}\",\n  \"chat_id\": \"{CHAT_ID}\"\n}",
+		"hasResultTransform": false
+	},
+	"openaiSpec": {
+		"name": "shared_pad",
+		"description": "Read or overwrite a persistent shared plain-text pad.",
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"action": {
+					"type": "string",
+					"enum": [
+						"get",
+						"set"
+					],
+					"description": "Choose get to read the pad, set to overwrite it."
+				},
+				"text": {
+					"type": "string",
+					"description": "Used when action is set"
+				}
+			},
+			"required": [
+				"action"
+			]
+		}
+	},
+	"outputType": "respond_to_ai",
+	"overviewMarkdown": "A plain shared text pad that both you and the assistant can read and overwrite."
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,16 @@
 {
-  "routes": [{ "src": "/(.*)", "dest": "/api/index.py" }]
+  "functions": { "api/index.py": { "runtime": "python3.11" } },
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/api/index.py" }
+  ],
+  "headers": [
+    {
+      "source": "/plugin.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, must-revalidate" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Serve `plugin.json` as a static asset by moving it to `public/` and updating `vercel.json` for static file handling, caching, and CORS headers.

This change ensures Vercel serves `plugin.json` directly as a static file, improving performance and efficiency compared to serving it through the API, and applies recommended caching and CORS headers.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a10f9bb-bc9d-4559-aea9-fe3f55ceb883">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a10f9bb-bc9d-4559-aea9-fe3f55ceb883">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

