### PR TITLE
Make curl exit non-zero on non-200 responses

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 echo "hi"
-curl -i https://typingmind-plugin-server.vercel.app/hi ;
+curl -i --fail https://typingmind-plugin-server.vercel.app/hi ;
 
 echo "first read"
-curl -i https://typingmind-plugin-server.vercel.app/pad/sanity-123 ; 
+curl -i --fail https://typingmind-plugin-server.vercel.app/pad/sanity-123 ; 
 
 echo "write"
-curl -i -X POST https://typingmind-plugin-server.vercel.app/pad/sanity-123 -H 'content-type: application/json' -d '{"text":"hello from curl"}' ;
+curl -i --fail -X POST https://typingmind-plugin-server.vercel.app/pad/sanity-123 -H 'content-type: application/json' -d '{"text":"hello from curl"}' ;
 
 echo "read again"
-curl -i https://typingmind-plugin-server.vercel.app/pad/sanity-123 ;
+curl -i --fail https://typingmind-plugin-server.vercel.app/pad/sanity-123 ;
 


### PR DESCRIPTION
Add `--fail` flag to curl commands in `test.sh` to ensure the script exits non-zero on HTTP errors (4xx/5xx).

---
<a href="https://cursor.com/background-agent?bcId=bc-01073e17-d39a-40e0-bd7f-105a309844ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01073e17-d39a-40e0-bd7f-105a309844ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

