### PR TITLE
Assert curl json responses in test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,13 +11,17 @@ response2=$(curl -s --fail https://typingmind-plugin-server.vercel.app/pad/sanit
 echo "$response2"
 [[ "$response2" = '{"text":""}' ]]
 
+# Generate a short random string
+rand=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 8)
+echo "Using random string: $rand"
+
 echo "write"
-response3=$(curl -s --fail -X POST https://typingmind-plugin-server.vercel.app/pad/sanity-123 -H 'content-type: application/json' -d '{"text":"hello from curl"}')
+response3=$(curl -s --fail -X POST https://typingmind-plugin-server.vercel.app/pad/sanity-123 -H 'content-type: application/json' -d "{\"text\":\"hello from curl $rand\"}")
 echo "$response3"
-[[ "$response3" = '{"ok":true,"text":"hello from curl"}' ]]
+[[ "$response3" = "{\"ok\":true,\"text\":\"hello from curl $rand\"}" ]]
 
 echo "read again"
 response4=$(curl -s --fail https://typingmind-plugin-server.vercel.app/pad/sanity-123)
 echo "$response4"
-[[ "$response4" = '{"text":"hello from curl"}' ]]
+[[ "$response4" = "{\"text\":\"hello from curl $rand\"}" ]]
 


### PR DESCRIPTION
Add JSON response assertions to `test.sh` to verify API outputs.

The `curl -i` flag was replaced with `curl -s` to capture only the JSON response body, enabling direct comparison with expected values. This ensures the script fails if API responses deviate from the log-observed behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-75b4cf6d-9dac-49b2-a490-707ad3d35231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75b4cf6d-9dac-49b2-a490-707ad3d35231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

